### PR TITLE
Improve string operations

### DIFF
--- a/ParserCommon/HeaderHelper.cs
+++ b/ParserCommon/HeaderHelper.cs
@@ -7,7 +7,6 @@ namespace TI.Declarator.ParserCommon
     public static class HeaderHelpers
     {
         public static bool HasRealEstateStr(string str) =>str
-            .ToLowerInvariant()
             .RemoveCharacters('-', ' ')
             .ContainsAny("недвижимости", "недвижимого", "иноенедвижимоеимущество(кв.м)");
 
@@ -119,7 +118,7 @@ namespace TI.Declarator.ParserCommon
 
         public static bool IsName(this string s)
         {
-            var clean = s.RemoveCharacters(',', '-', '\n', ' ').ToLowerInvariant();
+            var clean = s.RemoveCharacters(',', '-', '\n', ' ');
             return clean.StartsWithAny("лицаодоходах", "подающиесведения", "подающийсведения")
                     || clean.ContainsAny("фамилия", "фамилимя", "фио", ".иф.о.", "сведенияодепутате", "ф.и.о");
         }
@@ -131,7 +130,7 @@ namespace TI.Declarator.ParserCommon
         private static bool IsRelativeType(this string s) => s.ContainsAny("члены семьи", "степень родства") && !s.IsName();
 
         private static bool IsOccupation(this string s) => s
-            .RemoveCharacters('-', ' ').ToLowerInvariant()
+            .RemoveCharacters('-', ' ')
             .ContainsAny("должность", "должности", "должностей");
 
         private static bool IsDepartment(this string s) => s.ContainsAny("наименование организации", "ерриториальное управление в субъекте");

--- a/ParserCommon/TextHelpers.cs
+++ b/ParserCommon/TextHelpers.cs
@@ -62,11 +62,18 @@ namespace TI.Declarator.ParserCommon
         public static string RemoveStupidTranslit(this string str)
         {
             var builder = new StringBuilder(str);
+            builder.RemoveStupidTranslit();
+            return builder.ToString();
+        }
+
+        public static StringBuilder RemoveStupidTranslit(this StringBuilder builder)
+        {
             foreach (var (from, to) in TranslitCharacters)
             {
                 builder.Replace(from, to);
             }
-            return builder.ToString();
+
+            return builder;
         }
 
         public static string ReplaceEolnWithSpace(this string str) => str.Replace('\n', ' ').Trim();

--- a/lib/Adapters/AdapterSchemes/SovetFederaciiDocxScheme.cs
+++ b/lib/Adapters/AdapterSchemes/SovetFederaciiDocxScheme.cs
@@ -23,7 +23,7 @@ namespace Smart.Parser.Lib.Adapters.AdapterSchemes
             var tables = docPart.Document.Descendants<Table>().ToList();
 
             var paragraphs = docPart.Document.Descendants<Paragraph>().ToList();
-            var titles = paragraphs.FindAll(x => x.InnerText.ToLower().Contains("раздел"));
+            var titles = paragraphs.FindAll(x => x.InnerText.Contains("раздел", StringComparison.OrdinalIgnoreCase));
 
             if (titles.Count == 0)
                 return false;

--- a/lib/Adapters/AdapterSchemes/SovetFederaciiDocxScheme.cs
+++ b/lib/Adapters/AdapterSchemes/SovetFederaciiDocxScheme.cs
@@ -11,6 +11,7 @@ using Table = DocumentFormat.OpenXml.Wordprocessing.Table;
 using EP.Ner;
 using EP.Ner.Core;
 using EP.Morph;
+using System.Text;
 
 namespace Smart.Parser.Lib.Adapters.AdapterSchemes
 {
@@ -309,7 +310,7 @@ namespace Smart.Parser.Lib.Adapters.AdapterSchemes
 
         public string FindTitleAboveTheTable()
         {
-            string title = "";
+            var title = new StringBuilder();
             var body = Document.Body;
             foreach (var p in Document.Descendants<Paragraph>())
             {
@@ -318,10 +319,10 @@ namespace Smart.Parser.Lib.Adapters.AdapterSchemes
                     break;
                 }
 
-                title += p.InnerText + "\n";
+                title.Append(p.InnerText).Append('\n');
             }
 
-            return title.Trim().Replace("\n", " ");
+            return title.Replace('\n', ' ').ToString().Trim();
         }
 
         private int GetYear()

--- a/lib/Adapters/AngleHtmlAdapter.cs
+++ b/lib/Adapters/AngleHtmlAdapter.cs
@@ -188,7 +188,7 @@ namespace Smart.Parser.Adapters
             //var myFormatter = new AngleSharp.Html.PrettyMarkupFormatter();
             Text = inputCell.ToHtml(myFormatter);
             IsEmpty = Text.IsNullOrWhiteSpace();
-            if (FontName == null || FontName == "")
+            if (string.IsNullOrEmpty(FontName))
             {
                 FontName = docHolder.DefaultFontName;
             }

--- a/lib/Adapters/AngleHtmlAdapter.cs
+++ b/lib/Adapters/AngleHtmlAdapter.cs
@@ -386,7 +386,7 @@ namespace Smart.Parser.Adapters
                     tableIndex,
                     tableText));
             }
-            if (Title.Length == 0 && table.TextContent.Length > 30 && table.TextContent.ToLower().IndexOf("декабря") != -1)
+            if (Title.Length == 0 && table.TextContent.Length > 30 && table.TextContent.Contains("декабря", StringComparison.OrdinalIgnoreCase))
             {
                 var rows = new List<String>();
                 foreach (var r in GetHtmlTableRows(table))

--- a/lib/Adapters/AngleHtmlAdapter.cs
+++ b/lib/Adapters/AngleHtmlAdapter.cs
@@ -6,6 +6,7 @@ using TI.Declarator.ParserCommon;
 using AngleSharp;
 using AngleSharp.Dom;
 using Parser.Lib;
+using System.Text;
 
 namespace Smart.Parser.Adapters
 {
@@ -23,7 +24,7 @@ namespace Smart.Parser.Adapters
         
         public string FindTitleAboveTheTable()
         {
-            string title = "";
+            var title = new StringBuilder();
             bool foundTable = false;
             var addedLines = new HashSet<string>();
             foreach (var p in HtmlDocument.All.ToList() )
@@ -34,11 +35,11 @@ namespace Smart.Parser.Adapters
                 addedLines.Add(p.TextContent);
                 if (p.LocalName == "h1" || p.LocalName == "h2")
                 {
-                    title += p.TextContent + " ";
+                    title.Append(p.TextContent).Append(' ');
                 }
                 else if ((p.LocalName == "p" || p.LocalName == "div" || p.LocalName == "span") && p.TextContent.IndexOf("декабря") != -1)
                 {
-                    title += p.TextContent + " ";
+                    title.Append(p.TextContent).Append(' ');
                 }
                 else
                 {
@@ -50,12 +51,12 @@ namespace Smart.Parser.Adapters
                     {
                         if (p.LocalName == "p")
                         {
-                            title += p.TextContent + " ";
+                            title.Append(p.TextContent).Append(' ');
                         }
                     }
                 }
             }
-            return title;
+            return title.ToString();
         }
 
     }

--- a/lib/Adapters/AsposeDocAdapter.cs
+++ b/lib/Adapters/AsposeDocAdapter.cs
@@ -100,14 +100,14 @@ namespace Smart.Parser.Adapters
             { 
                 node = node.PreviousSibling;
             }
-            string text = "";
+            var text = new StringBuilder();
             while (node.NextSibling != table)
             {
-                text += node.ToString();
+                text.Append(node.ToString());
                 node = node.NextSibling;
             }
 
-            title = text;
+            title = text.ToString();
         }
 
         private Aspose.Words.Tables.Table table;

--- a/lib/Adapters/BigramsHolder.cs
+++ b/lib/Adapters/BigramsHolder.cs
@@ -107,7 +107,7 @@ namespace Smart.Parser.Adapters
                             joinExplanation = "non-closed ) regexp";
                         }
 
-                        if (firstWord.Trim()[0] == '(')
+                        if (firstWord.TrimStart()[0] == '(')
                         {
                             joinExplanation = "open ( regexp";
                         }

--- a/lib/Adapters/ConvertToDocxAndFix.cs
+++ b/lib/Adapters/ConvertToDocxAndFix.cs
@@ -184,7 +184,7 @@ namespace Smart.Parser.Adapters
         }
         public String ConvertWithSoffice(string fileName)
         {
-            if (fileName.ToLower().EndsWith("pdf"))
+            if (fileName.EndsWith("pdf", StringComparison.OrdinalIgnoreCase))
             {
                 throw new SmartParserException("libre office cannot convert pdf");
             }

--- a/lib/Adapters/HtmlSchemes/ArbitrationCourt1.cs
+++ b/lib/Adapters/HtmlSchemes/ArbitrationCourt1.cs
@@ -246,12 +246,8 @@ namespace Smart.Parser.Lib.Adapters.HtmlSchemes
 
             if (_collegiumColumNum == -1)
                 return;
-            string value;
-            if (isMain)
-                value = _collegium;
-            else
-                value = "";
-            for(int i = 1; i < lines.Count; i += 1)
+            string value = isMain ? _collegium : "";
+            for (int i = 1; i < lines.Count; i += 1)
             {
                 lines[i].Insert(_collegiumColumNum, value);
             }
@@ -279,12 +275,7 @@ namespace Smart.Parser.Lib.Adapters.HtmlSchemes
 
         protected static string GetMatchResult(Match match)
         {
-            if (match.Success)
-            {
-                return match.Value;
-            }
-
-            return "-";
+            return match.Success ? match.Value : "-";
         }
 
         #endregion

--- a/lib/Adapters/IAdapter.cs
+++ b/lib/Adapters/IAdapter.cs
@@ -208,27 +208,28 @@ namespace Smart.Parser.Adapters
 
         string GetHtmlByRow(List<Cell> row, int rowIndex)
         {
-            string res = string.Format("<tr rowindex={0}>\n", rowIndex);
+            StringBuilder res = new StringBuilder();
+            res.AppendFormat("<tr rowindex={0}>\n", rowIndex);
             foreach (var c in row)
             {
                 if (c.FirstMergedRow != rowIndex)
                 {
                     continue;
                 }
-                res += "\t<td";
+                res.Append("\t<td");
                 if (c.MergedColsCount > 1)
                 {
-                    res += string.Format(" colspan={0}", c.MergedColsCount);
+                    res.AppendFormat(" colspan={0}", c.MergedColsCount);
                 }
                 if (c.MergedRowsCount > 1)
                 {
-                    res += string.Format(" rowspan={0}", c.MergedRowsCount);
+                    res.AppendFormat(" rowspan={0}", c.MergedRowsCount);
                 }
                 string text = c.Text.Replace("\n", "<br/>");
-                res += ">" + text + "</td>\n";
+                res.AppendFormat(">" + text + "</td>\n");
             }
-            res += "</tr>\n";
-            return res;
+            res.Append("</tr>\n");
+            return res.ToString();
         }
 
         public TJsonTablePortion TablePortionToJson(ColumnOrdering columnOrdering, int body_start, int body_end)

--- a/lib/Adapters/IAdapter.cs
+++ b/lib/Adapters/IAdapter.cs
@@ -133,10 +133,11 @@ namespace Smart.Parser.Adapters
             }
             return -1;
         }
+
+        private static readonly ISet<string> DaysOfWeek = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "пн", "вт", "ср", "чт", "пт", "сб", "вс" };
         protected static List<List<T>> DropDayOfWeekRows<T>(List<List<T>> tableRows) where T : Cell
         {
-            List<string> daysOfWeek = new List<string> { "пн", "вт", "ср", "чт", "пт", "сб", "вс" };
-            return  tableRows.TakeWhile(x => !x.All(y => daysOfWeek.Contains(y.Text.ToLower().Trim()))).ToList();
+            return  tableRows.TakeWhile(x => !x.All(y => DaysOfWeek.Contains(y.Text.Trim()))).ToList();
         }
 
         protected static bool CheckNameColumnIsEmpty<T>(List<List<T>> tableRows, int start) where T : Cell

--- a/lib/Adapters/IAdapterRow.cs
+++ b/lib/Adapters/IAdapterRow.cs
@@ -227,7 +227,7 @@ namespace Smart.Parser.Adapters
                     var field = columnOrdering.FindByPixelIntersection(start, start + c.CellWidth, out interSize);
                    
                     // cannot map some text,so it is a failure
-                    if (field == DeclarationField.None && c.Text.Trim().Length > 0)
+                    if (field == DeclarationField.None && !string.IsNullOrWhiteSpace(c.Text))
                     {
                         return null;
                     }
@@ -271,7 +271,7 @@ namespace Smart.Parser.Adapters
             }
             TColumnInfo colSpan;
             var exactCell = adapter.GetDeclarationFieldWeak(ColumnOrdering, row, field, out colSpan);
-            if (exactCell.Text.Trim() != "" || exactCell.Col == -1)
+            if (!string.IsNullOrWhiteSpace(exactCell.Text) || exactCell.Col == -1)
             {
                 return exactCell;
             }
@@ -282,7 +282,7 @@ namespace Smart.Parser.Adapters
                 {
                     break;
                 }
-                if (mergedCell.Text.Trim() != "")
+                if (!string.IsNullOrWhiteSpace(mergedCell.Text))
                 {
                     return mergedCell;
                 }

--- a/lib/Adapters/IAdapterRow.cs
+++ b/lib/Adapters/IAdapterRow.cs
@@ -138,12 +138,14 @@ namespace Smart.Parser.Adapters
         }
         public string DebugString()
         {
-            string s = "";
+            var s = new StringBuilder();
             foreach (var c in Cells)
             {
-                s += string.Format("\"{0}\"[{1}], ",c.Text.Replace("\n", "\\n"),c.CellWidth);
+                s.AppendFormat("\"{0}\"[{1}], ", c.Text, c.CellWidth);
             }
-            return s;
+            s.Replace("\n", "\\n");
+
+            return s.ToString();
         }
 
         public DataRow DeepClone()

--- a/lib/Adapters/OpenXmlWord.cs
+++ b/lib/Adapters/OpenXmlWord.cs
@@ -682,7 +682,7 @@ namespace Smart.Parser.Adapters
                     tableIndex,
                     tableText));
             }
-            if (Title.Length == 0 && table.InnerText.Length > 30 && table.InnerText.ToLower().IndexOf("декабря") != -1)
+            if (Title.Length == 0 && table.InnerText.Length > 30 && table.InnerText.Contains("декабря", StringComparison.OrdinalIgnoreCase))
             {
                 var rows = new List<String>();
                 foreach (var r in table.Descendants<TableRow>())

--- a/lib/Adapters/OpenXmlWord.cs
+++ b/lib/Adapters/OpenXmlWord.cs
@@ -13,6 +13,7 @@ using Parser.Lib;
 using System.Xml.Linq;
 using Smart.Parser.Lib.Adapters.AdapterSchemes;
 using Smart.Parser.Lib.Adapters.DocxSchemes;
+using System.Text;
 
 namespace Smart.Parser.Adapters
 {
@@ -150,7 +151,7 @@ namespace Smart.Parser.Adapters
         }
         public string FindTitleAboveTheTable()
         {
-            string title = "";
+            var title = new StringBuilder();
             var body = WordDocument.MainDocumentPart.Document.Body;
             foreach (var p in WordDocument.MainDocumentPart.Document.Descendants<Paragraph>())
             {
@@ -158,9 +159,9 @@ namespace Smart.Parser.Adapters
                 {
                     break;
                 }
-                title += p.InnerText + "\n";
+                title.Append(p.InnerText).Append("\n");
             }
-            return title;
+            return title.ToString();
         }
 
     }
@@ -250,7 +251,7 @@ namespace Smart.Parser.Adapters
 
         private void InitTextProperties(WordDocHolder docHolder, OpenXmlElement inputCell)
         {
-            string s = "";
+            var s = new StringBuilder();
             FontName = "";
             FontSize = 0;
             foreach (var p in inputCell.Elements<Paragraph>())
@@ -276,35 +277,36 @@ namespace Smart.Parser.Adapters
                     }
                     else if (textOrBreak.LocalName == "t")
                     {
-                        s += textOrBreak.InnerText;
+                        s.Append(textOrBreak.InnerText);
                     }
                     else if (textOrBreak.LocalName == "cr")
                     {
-                        s += "\n";
+                        s.Append("\n");
                     }
                     else if (textOrBreak.LocalName == "br")
                     /* do  not use lastRenderedPageBreak, see MinRes2011 for wrong lastRenderedPageBreak in Семенов 
                     ||
                           (textOrBreak.Name == w + "lastRenderedPageBreak") */
                     {
-                        s += "\n";
+                        s.Append("\n");
                     } else if (textOrBreak.LocalName == "numPr")
                     {
-                        s += "- ";
+                        s.Append("- ");
                     }
                 }
-                s += "\n";
+                s.Append("\n");
                 ParagraphProperties pPr = p.ParagraphProperties;
                 if (pPr != null)
                 {
                     for (int l = 0; l < AfterLinesCount(pPr.SpacingBetweenLines); ++l)
                     {
-                        s += "\n";
+                        s.Append("\n");
                     }
                 }
             }
-            Text = s;
-            IsEmpty = s.IsNullOrWhiteSpace();
+            var text = s.ToString();
+            Text = text;
+            IsEmpty = text.IsNullOrWhiteSpace();
             if (string.IsNullOrEmpty(FontName))
             {
                 FontName = docHolder.DefaultFontName;

--- a/lib/Adapters/Section.cs
+++ b/lib/Adapters/Section.cs
@@ -96,7 +96,7 @@ namespace Smart.Parser.Adapters
             bool hasStopWord = false;
             foreach (var word in stopWords)
             {
-                if (rowText.ToLower() == word) hasStopWord = true;
+                if (rowText.Equals(word, StringComparison.OrdinalIgnoreCase)) hasStopWord = true;
             }
             if (hasStopWord) return false;
             

--- a/lib/ColumnDetector.cs
+++ b/lib/ColumnDetector.cs
@@ -313,7 +313,7 @@ namespace Smart.Parser.Lib
 
                 if (adapter.GetRowsCount() == cell.MergedRowsCount)
                     continue;
-                if (cell.CellWidth == 0 && text.Trim() == "") continue;
+                if (cell.CellWidth == 0 && string.IsNullOrWhiteSpace(text)) continue;
 
                 if (maxMergedRows < cell.MergedRowsCount)
                     maxMergedRows = cell.MergedRowsCount;
@@ -324,7 +324,7 @@ namespace Smart.Parser.Lib
                     headerEndRow = Math.Max(headerEndRow, cell.Row + cell.MergedRowsCount);
 
                     // иногда в двухярусном заголовке в верхней клетке пусто, а в нижней есть заголовок (TwoRowHeaderEmptyTopCellTest)
-                    if (text.Trim() == "" && cell.MergedRowsCount < maxMergedRows && underCells.Count() == 1) 
+                    if (string.IsNullOrWhiteSpace(text) && cell.MergedRowsCount < maxMergedRows && underCells.Count() == 1) 
                     {
                         columnCells.Add(underCells.First());
                     }

--- a/lib/ColumnDetector.cs
+++ b/lib/ColumnDetector.cs
@@ -22,11 +22,8 @@ namespace Smart.Parser.Lib
         static public bool GetValuesFromTitle(string text, ref string title, ref int? year, ref string ministry)
         {
             int text_len = text.Length;
-            if (title == null)
-                title = text;
-            else
-                title += " " + text;
-            
+            title = title == null ? text : title + " " + text;
+
             text = text.ToLower();
             string[] title_words = { "сведения", "обязательствах", "доход", "период" };
             bool has_title_words = Array.Exists(title_words, s => text.Contains(s));
@@ -188,8 +185,8 @@ namespace Smart.Parser.Lib
             if (subCells.Count == 1)
                 return;
 
-            string cleanHeader = headerCell.Text.ToLower().Replace(" ", "");
-            if (cleanHeader.Contains("транспортныесредства") && cleanHeader.Contains("марка") && cleanHeader.Contains("вид"))
+
+            if (headerCell.Text.RemoveCharacters(' ').ContainsAll("транспортныесредства", "марка", "вид"))
             {
 
                 TColumnInfo columnVehicleType = new TColumnInfo();

--- a/lib/ColumnDetector.cs
+++ b/lib/ColumnDetector.cs
@@ -26,7 +26,7 @@ namespace Smart.Parser.Lib
 
             text = text.ToLower();
             string[] title_words = { "сведения", "обязательствах", "доход", "период" };
-            bool has_title_words = Array.Exists(title_words, s => text.Contains(s));
+            bool has_title_words = title_words.Any(s => text.Contains(s));
             if (!has_title_words)
                 return false;
 

--- a/lib/DataHelper.cs
+++ b/lib/DataHelper.cs
@@ -90,8 +90,7 @@ namespace Smart.Parser.Lib
                 .RemoveCharacters(' ', ':', '-', '\n', '.')
                 .Replace('ё', 'е')
                 .Trim()
-                .RemoveStupidTranslit()
-                .ToLower();
+                .RemoveStupidTranslit();
 
             return clean switch
             {

--- a/lib/DataHelper.cs
+++ b/lib/DataHelper.cs
@@ -6,6 +6,7 @@ using TI.Declarator.ParserCommon;
 using Newtonsoft.Json;
 using System.Reflection;
 using SmartAntlr;
+using System.Text;
 
 namespace Smart.Parser.Lib
 {
@@ -192,13 +193,17 @@ namespace Smart.Parser.Lib
 
         public static string TryParseRealEstateType(string strType)
         {
-            var key = strType.ToLower().RemoveStupidTranslit()
-                                          .Trim('\"')
-                                          .Replace('\n', ' ')
-                                          .Replace(';', ' ')
-                                          .Replace("не имеет", string.Empty)
-                                          .CoalesceWhitespace()
-                                          .Trim();
+            var key = new StringBuilder(
+                    strType
+                        .ToLower()
+                        .Trim('"'))
+                .RemoveStupidTranslit()
+                .Replace('\n', ' ')
+                .Replace(';', ' ')
+                .Replace("не имеет", string.Empty)
+                .ToString()
+                .CoalesceWhitespace()
+                .Trim();
 
             return key;
         }

--- a/lib/RealtyParser.cs
+++ b/lib/RealtyParser.cs
@@ -199,8 +199,9 @@ namespace Smart.Parser.Lib
 
         static public void SwapCountryAndSquare(ref string squareStr, ref string countryStr)
         {
-            if ((squareStr.ToLower().Trim() == "россия" ||
-                 squareStr.ToLower().Trim() == "рф") &&
+            string squareStrClean = squareStr.ToLower().Trim();
+            if ((squareStrClean == "россия" ||
+                 squareStrClean == "рф") &&
                 Regex.Match(countryStr.Trim(), @"[0-9,.]").Success)
             {
                 var t = squareStr;
@@ -358,7 +359,7 @@ namespace Smart.Parser.Lib
                 item = SliceArrayAndTrim(lines, startLine, i);
                 if (item.Count() > 0) // not empty item
                 {
-                    if ((numberIndex < linesWithNumbers.Count && i == linesWithNumbers[numberIndex]) || lines[i].Trim().Count() == 0)
+                    if ((numberIndex < linesWithNumbers.Count && i == linesWithNumbers[numberIndex]) || string.IsNullOrWhiteSpace(lines[i]))
                     {
                         result.Add(item);
                         startLine = i;

--- a/tools/Office2Txt/Program.cs
+++ b/tools/Office2Txt/Program.cs
@@ -5,6 +5,7 @@ using System.IO;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Wordprocessing;
+using System.Text;
 
 namespace Office2Txt
 {
@@ -12,24 +13,24 @@ namespace Office2Txt
     {
         static string ProcessDocxPart(OpenXmlPartRootElement part)
         {
-            string s = "";
+            var s = new StringBuilder();
             foreach (var p in part.Descendants<Paragraph>())
             {
-                s += p.InnerText + "\n";
+                s.Append(p.InnerText).Append('\n');
             }
-            return s;
+            return s.ToString();
         }
         static string ProcessDocx(string inputFile)
         {
             WordprocessingDocument doc =
                 WordprocessingDocument.Open(inputFile, false);
-            string s = "";
+            var s = new StringBuilder();
             foreach (OpenXmlPart h in doc.MainDocumentPart.HeaderParts) {
-                s += ProcessDocxPart(h.RootElement);
+                s.Append(ProcessDocxPart(h.RootElement));
             };
-            s += ProcessDocxPart(doc.MainDocumentPart.Document);
+            s.Append(ProcessDocxPart(doc.MainDocumentPart.Document));
             doc.Close();
-            return s;
+            return s.ToString();
         }
         static void Main(string[] args)
         {


### PR DESCRIPTION
* Поклейка строк в циклах заменена на `StringBuilder`
* `.Trim() == ""` на `string.IsNullOrWhiteSpace()`
* Сравнения `.ToLower()` на `Equals` / `Contains` / `etc` с регистронезависимым `StringComparer` / `StringComparison`.
* Убраны `.ToLowerInvariant()` перед вызовом регистронезависимой `.ContainsAny()`

Результат тот же, а работает лучше — выкидывается много тяжёлых операций по созданию строк.

